### PR TITLE
Pass month/day values to mktime() without any leading zeros

### DIFF
--- a/api/download.php
+++ b/api/download.php
@@ -9,8 +9,8 @@ if ( isset( $_GET['key'] ) ) {
         // loop over all the versions for each theme and plugin
         foreach ( $package['versions'] as $version ) {
             // md5 timestamp of current and previous day and the file name
-            $tod_md5 = md5( $version['file_name'] . mktime( 0, 0, 0, date( "m" ), date( "d" ), date( "Y" ) ) );
-            $yes_md5 = md5( $version['file_name'] . mktime( 0, 0, 0, date( "m" ), date( "d" ) - 1, date( "Y" ) ) );
+            $tod_md5 = md5( $version['file_name'] . mktime( 0, 0, 0, date( "n" ), date( "j" ), date( "Y" ) ) );
+            $yes_md5 = md5( $version['file_name'] . mktime( 0, 0, 0, date( "n" ), date( "j" ) - 1, date( "Y" ) ) );
             // test if the either of the md5 hashes match what was passed
             if ( $_GET['key'] == $tod_md5 || $_GET['key'] == $yes_md5 ) {
                 $download = $update_folder . $version['file_name'];

--- a/api/packages.php
+++ b/api/packages.php
@@ -6,7 +6,7 @@ $packages['theme'] = array( //Replace theme with theme stylesheet slug that the 
             'version' => '1.0', //Current version available
             'date' => '2010-04-10', //Date version was released
             //theme.zip is the same as file_name
-            'package' => 'http://url_to_your_site/download.php?key=' . md5('theme.zip' . mktime(0,0,0,date("m"),date("d"),date("Y"))),
+            'package' => 'http://url_to_your_site/download.php?key=' . md5('theme.zip' . mktime(0,0,0,date("n"),date("j"),date("Y"))),
             //file_name is the name of the file in the update folder.
             'file_name' => 'theme.zip',	//File name of theme zip file
             'author' => 'Author Name', //Author of theme
@@ -34,7 +34,7 @@ $packages['test-plugin-update'] = array( //Replace plugin with the plugin slug t
             'downloaded' => '1000', // Number of times downloaded
             'external' => '', // Unused
             //plugin.zip is the same as file_name
-            'package' => 'http://url_to_your_site/download.php?key=' . md5('plugin.zip' . mktime(0,0,0,date("m"),date("d"),date("Y"))),
+            'package' => 'http://url_to_your_site/download.php?key=' . md5('plugin.zip' . mktime(0,0,0,date("n"),date("j"),date("Y"))),
             //file_name is the name of the file in the update folder.
             'file_name' => 'plugin.zip',
             'sections' => array(


### PR DESCRIPTION
`date("m")` and `date("d")` includes a leading zero when necessary (e.g. "01"). While I don't think these are causing any problems now, it's probably better to switch to values without the leading zero.
